### PR TITLE
move period ouside of mailto link

### DIFF
--- a/pages/insights/index.njk
+++ b/pages/insights/index.njk
@@ -15,7 +15,7 @@ hero:
   <div class="grid-container">
     <p class="font-body-lg text-semibold">
       We’re keeping up with trending information about the future of federal work, with an eye toward the ways federal agencies manage space and perform hybrid work. Interested in seeing information about a specific topic?
-      Let us know by emailing us at <a href="mailto:workplace@gsa.gov">workplace@gsa.gov.</a></p>
+      Let us know by emailing us at <a href="mailto:workplace@gsa.gov">workplace@gsa.gov</a>.</p>
 
 
     <div class="grid-container padding-top-205">


### PR DESCRIPTION
Just scoots the period over a bit so it's no longer linked.