### PR TITLE
Applies aria label fix to homepage insight image links

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -29,7 +29,7 @@ hero:
   {% for insight in collections.insights.slice(0, 3) %}
     <div class="tablet:grid-col-4">
       <div class="flex-column">
-      <a class="usa-link text-no-underline text-black" href="{{ insight.url | url }}">
+      <a class="usa-link text-no-underline text-black" href="{{ insight.url | url }}" aria-label="link to {{ insight.data.title }}">
         <img
         src="{{ insight.data.image.url | url }}"
         alt="{{insight.data.image.alt}}"


### PR DESCRIPTION
- Fixes [issue 47](https://github.com/GSA/wp2030-microsite-new/issues/47)
- Applies same `aria-label` fix used by @weiwang-gsa on insights index page to clear accessibility error on homepage