### PR TITLE
remove grid breakpoint causing wrap on larger screens

### DIFF
--- a/_includes/components/hero.njk
+++ b/_includes/components/hero.njk
@@ -6,7 +6,7 @@
       </h1>
     {% endif %}
     {% if hero.callout %}
-      <p class="tablet:grid-col-8">{{ hero.callout }}</p>
+      <p>{{ hero.callout }}</p>
     {% endif %}
     {% if hero.action %}
       <a class="usa-button text-uppercase" href="{{ hero.action.href | url }}">{{ hero.action.text }}</a>


### PR DESCRIPTION
Removes the grid column token which was causing hero subtext to wrap on screens larger than tablets. Text should remain unchanged for smaller screens. 