### PR TITLE
remove margin bottom from hero callout

### DIFF
--- a/_includes/components/hero.njk
+++ b/_includes/components/hero.njk
@@ -6,7 +6,7 @@
       </h1>
     {% endif %}
     {% if hero.callout %}
-      <p>{{ hero.callout }}</p>
+      <p class="margin-bottom-0">{{ hero.callout }}</p>
     {% endif %}
     {% if hero.action %}
       <a class="usa-button text-uppercase" href="{{ hero.action.href | url }}">{{ hero.action.text }}</a>


### PR DESCRIPTION
Fixes centering issue on hero banner introduced by removing wrap. For [#57](https://github.com/GSA/wp2030-microsite-new/issues/57#issuecomment-1402769188)