### PR TITLE
Changes heading level to sequential order

### DIFF
--- a/pages/offerings/index.njk
+++ b/pages/offerings/index.njk
@@ -20,9 +20,9 @@ hero:
       {% for offering in collections.offerings | sort(attribute='data.sortorder') %}
         <div class="tablet:grid-col-6">
           <div class="border-top border-base-light">
-            <h3 class="font-heading-lg">
+            <h2 class="font-heading-lg">
               <a class="usa-link text-no-underline" href="{{ offering.url | url }}">{{ offering.data.tagline }}</a>
-            </h3>
+            </h2>
             <p>
               {{ offering.data.description }}
             </p>


### PR DESCRIPTION
- Fixes [issue 46](https://github.com/GSA/wp2030-microsite-new/issues/46)
- Changes offerings headings to `h2` to avoid skipping from `h1` to `h3`s

Font size should remain the same based on class `font-heading-lg', but please double check @jfredrickson5.