### PR TITLE
Fix previews

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -1,5 +1,4 @@
 const eleventyNavigationPlugin = require("@11ty/eleventy-navigation");
-const { EleventyHtmlBasePlugin } = require("@11ty/eleventy");
 const markdownItAnchor = require("markdown-it-anchor");
 const markdownItAttrs = require("markdown-it-attrs");
 const yaml = require("js-yaml");
@@ -14,7 +13,6 @@ module.exports = function(eleventyConfig) {
 
   // Add 11ty plugins
   eleventyConfig.addPlugin(eleventyNavigationPlugin);
-  eleventyConfig.addPlugin(EleventyHtmlBasePlugin);
 
   // Add markdown-it plugins
   eleventyConfig.amendLibrary("md", md => md.use(markdownItAnchor));


### PR DESCRIPTION
The 11ty html base plugin should no longer be needed; remove it to get preview URLs working again.