### PR TITLE
Mmeyer/205 insight ordering

### DIFF
--- a/modules/filters.js
+++ b/modules/filters.js
@@ -4,6 +4,7 @@ const striptags = require("striptags");
 
 module.exports = (eleventyConfig) => {
   eleventyConfig.addFilter("postDate", dateObj => DateTime.fromJSDate(dateObj).toLocaleString(DateTime.DATE_FULL));
+  eleventyConfig.addFilter("take", (collection, n) => collection.slice(0, n));
 
   eleventyConfig.addFilter("search", (collection) => {
     const searchIndex = elasticlunr(function () {

--- a/pages/index.html
+++ b/pages/index.html
@@ -26,7 +26,8 @@ hero:
 <p>Learn more about government workplace trends and best practices in workplace strategy.</p>
 
 <div class="grid-row grid-gap">
-  {% for insight in collections.insights.slice(0, 3) %}
+  {% for insight in collections.insights | sort(attribute='data.sortorder') | reverse | take(3) %}
+  {# {% for insight in (collections.insights | sort(attribute='data.sortorder')).slice(0, 3) %} #}
     <div class="tablet:grid-col-4 margin-y-3">
       <div class="flex-column">
       <a class="usa-link text-no-underline text-black" href="{{ insight.url | url }}" aria-label="link to {{ insight.data.title }}">

--- a/pages/index.html
+++ b/pages/index.html
@@ -27,7 +27,6 @@ hero:
 
 <div class="grid-row grid-gap">
   {% for insight in collections.insights | sort(attribute='data.sortorder') | reverse | take(3) %}
-  {# {% for insight in (collections.insights | sort(attribute='data.sortorder')).slice(0, 3) %} #}
     <div class="tablet:grid-col-4 margin-y-3">
       <div class="flex-column">
       <a class="usa-link text-no-underline text-black" href="{{ insight.url | url }}" aria-label="link to {{ insight.data.title }}">

--- a/pages/insights/1-interesting-times-produce-creative-opportunities.md
+++ b/pages/insights/1-interesting-times-produce-creative-opportunities.md
@@ -7,7 +7,7 @@ position: Chief Architect
 image: 
   url: /assets/img/insights-interesting.jpg
   alt: A group of people in business attire working at a modern conference table
-sortorder: 5
+sortorder: 500
 permalink: /insights/interesting-times-produce-creative-opportunities/
 tags: insights
 

--- a/pages/insights/2-coworking-pilot-lesson-learned.md
+++ b/pages/insights/2-coworking-pilot-lesson-learned.md
@@ -7,7 +7,7 @@ position: Client Communication Specialist
 image: 
   url: /assets/img/insights-lesson-learned.jpg
   alt: People with laptops at a conference table meeting with another team remotely
-sortorder: 6
+sortorder: 400
 permalink: /insights/commercial-coworking-pilot-lessons-learned/
 tags: insights
 

--- a/pages/insights/3-USAID-GSA.md
+++ b/pages/insights/3-USAID-GSA.md
@@ -8,7 +8,7 @@ position:
 image: 
   url: /assets/img/insights-USAID-GSA.jpg
   alt: Two people having a conversation in a large, modern office building foyer
-sortorder: 7
+sortorder: 300
 permalink: /insights/usaid-gsa-consolidating-space-to-drive-cost-avoidance/
 tags: insights
 

--- a/pages/insights/4-NRC-GSA.md
+++ b/pages/insights/4-NRC-GSA.md
@@ -7,7 +7,7 @@ position:
 image:
   url: /assets/img/insights-NRC-GSA.jpg
   alt: A modern conference room with abundant natural light
-sortorder: 8
+sortorder: 200
 permalink: /insights/nrc-gsa-space-reduction-and-cost-savings-in-new-lease/
 tags: insights
 

--- a/pages/insights/5-customer-collaboration.md
+++ b/pages/insights/5-customer-collaboration.md
@@ -7,7 +7,7 @@ position: Supervisory Communications Specialist
 image:
   url: /assets/img/insights-guest-gsa.jpg
   alt: A group of people on a stage in a panel discussion
-sortorder: 9
+sortorder: 100
 permalink: /insights/gsas-customer-collaboration-event-recap/
 tags: insights
 

--- a/pages/insights/commercial-coworking-usgs.md
+++ b/pages/insights/commercial-coworking-usgs.md
@@ -7,7 +7,7 @@ position: Public Affairs Officer
 image:
   url: /assets/img/insight-commercial-coworking-usgs.jpg
   alt: A large foyer with a staircase from one level to another and a L-shaped blue couch with coffee table; rugs and carpeting cover part of the area, while exposed concrete floor is exposed elsewhere; a hallway leads to elevators, and another staircase leads down to an area with a green exit sign.
-sortorder: 3
+sortorder: 700
 permalink: /insights/commercial-coworking-a-solution-for-usgs/
 tags: insights
 

--- a/pages/insights/future-work-starts-now.md
+++ b/pages/insights/future-work-starts-now.md
@@ -8,7 +8,7 @@ externallink: https://www.gsa.gov/blog/2023/02/13/the-future-of-work-starts-now
 image: 
   url: /assets/img/insights-future-work.jpg
   alt: "GSA leaders opening the Workplace Innovation Lab during a ribbon cutting ceremony."
-sortorder: 1
+sortorder: 900
 tags: insights
 
 ---

--- a/pages/insights/index.njk
+++ b/pages/insights/index.njk
@@ -20,7 +20,7 @@ hero:
 
     <div class="grid-container padding-top-205">
       <div class="grid-row grid-gap">
-      {% for insight in collections.insights | sort(attribute='data.sortorder') %}
+      {% for insight in collections.insights | sort(attribute='data.sortorder') | reverse %}
         <div class="tablet:grid-col-4 margin-y-1 padding-bottom-6">
           <div class="flex-column">
              {% if insight.data.externallink %}

--- a/pages/insights/opm-hybrid-toolkit.md
+++ b/pages/insights/opm-hybrid-toolkit.md
@@ -6,7 +6,7 @@ externallink: https://www.opm.gov/policy-data-oversight/future-of-the-workforce/
 image: 
   url: /assets/img/insights-hybrid-toolkit.jpg
   alt: Sticky notes on paper in a bracket structure; the notes read In-office and Remote while a hand presses a third sticky note that reads Hybrid where the bracket converges, with a stack of yellow sticky notes, markers, and a ruler nearby
-sortorder: 4
+sortorder: 600
 tags: insights
 
 ---

--- a/pages/insights/opm-workforce-guidiance.md
+++ b/pages/insights/opm-workforce-guidiance.md
@@ -6,7 +6,7 @@ externallink: https://www.opm.gov/policy-data-oversight/future-of-the-workforce/
 image: 
   url: /assets/img/insights-workforce-guidiance.jpg
   alt: A diverse group of people in a conference room with two people standing near a whiteboard showing several charts and graphs while four others are seated at a conference table listening; a bicycle is leaning against one wall, and there are several windows on one side of the room.
-sortorder: 2
+sortorder: 800
 tags: insights
 
 ---


### PR DESCRIPTION
- changes the sort order of  insight articles to make it easier to add new articles. 
- changes the `sortorder` in the front-matter to multiples of 100 so it is possible to insert items without needing to edit lower items
- adds a `take(n)` filter for readability and to make chaining easier. It will take the top `n` items from a collection 