### PR TITLE
Adds (more) meta descriptions to front matter

### DIFF
--- a/pages/404.md
+++ b/pages/404.md
@@ -5,6 +5,6 @@ permalink: 404.html
 eleventyExcludeFromCollections: true
 ---
 
-# Page not found
+# We couldn’t find that workplace.
 
-The requested page could not be found (error 404).
+We’re sorry, but we couldn’t find what you’re looking for. [Let us know if we’re missing something]({{ '/contact/' | url }}).

--- a/pages/about.html
+++ b/pages/about.html
@@ -1,6 +1,7 @@
 ---
 layout: layouts/page
 title: About
+description: The way we work today is fundamentally different than it was 20 years ago. GSA works with clients to support their mission delivery by integrating people, spaces, and technology.
 permalink: /about/
 eleventyNavigation:
   key: About

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -1,6 +1,7 @@
 ---
 layout: layouts/page
 title: Contact
+description: Find your national customer lead or regional account manager, follow GSA on social media, or contact us with workplace questions or press inquiries.
 permalink: /contact/
 eleventyNavigation:
   key: Contact

--- a/pages/insights/index.njk
+++ b/pages/insights/index.njk
@@ -1,6 +1,7 @@
 ---
 layout: layouts/base
 title: Insights
+description: GSA tracks industry trends about the future of work. Our insights cover a range of topics that help federal agencies manage space and perform hybrid work.
 permalink: /insights/
 eleventyNavigation:
   key: Insights

--- a/pages/offerings/index.njk
+++ b/pages/offerings/index.njk
@@ -1,6 +1,7 @@
 ---
 layout: layouts/base
 title: Offerings
+description: GSA has created workplace offerings that help agencies meet their missions, including the Workplace Innovation Lab, workplace engagement services, commercial coworking spaces, and workplace modeling tools.
 permalink: /offerings/
 eleventyNavigation:
   key: Offerings

--- a/pages/search.njk
+++ b/pages/search.njk
@@ -1,5 +1,6 @@
 ---
 title: Search
+description: Search for workplace and real estate solutions and tools.
 permalink: /search/
 layout: layouts/page
 ---


### PR DESCRIPTION
- My [last PR](#210) didn't include descriptions for landing pages, so this pull request adds meta descriptions for the additional pages.
- This PR _doesn't_ include descriptions for the homepage, 404 page, or a global description to be used for pages that might not have a description.
- Includes a minor change to the 404 page.