### PR TITLE
Replaces hyphen with en dash on about page

### DIFF
--- a/pages/about.html
+++ b/pages/about.html
@@ -16,7 +16,7 @@ hero:
   The way we work today is fundamentally different than it was 20 years ago, and
   the last few years have provided opportunities for radical change. In both the
   public and private sectors, people are moving toward a combination of
-  office-based, hybrid, and remote ways of working. GSA works with clients to support their mission delivery – wherever it occurs - by integrating people, spaces, and technology.
+  office-based, hybrid, and remote ways of working. GSA works with clients to support their mission delivery – wherever it occurs – by integrating people, spaces, and technology.
   </p>
 
 </div>


### PR DESCRIPTION
While reviewing the site for quote styling, I noticed a discrepancy in the use of dashes.

The `about` page uses dashes for a parenthetical. In production, one dash (the first) is a `en` dash, while the other is a `hyphen`.

This pull request changes the second dash to an `en` dash to match the opening dash of the parenthetical.

## Production
![A block of text using a parenthetical that with one long dash and one short dash](https://user-images.githubusercontent.com/32855580/224146358-5342c4e5-f31a-42f3-af90-15ede28da8cd.png)

## This pull request
![A block of text using a parenthetical that with dashes of equal length](https://user-images.githubusercontent.com/32855580/224146367-c89cc6b6-78e8-4fb9-b8ee-bd046090002f.png)


