### PR TITLE
update the css to resolve lead photo issue

### DIFF
--- a/_includes/layouts/insight.njk
+++ b/_includes/layouts/insight.njk
@@ -31,9 +31,9 @@ breadcrumb:
             <img
               src="{{image.url | url}}"
               aria-hidden="true"
-              class="width-full maxh-mobile"
+              class="maxh-mobile-lg"
               alt="{{image.alt}}"
-              style="object-fit: cover;"
+              style="object-fit: contain;"
             />
             {{ content | safe }}
       <div>


### PR DESCRIPTION
original CSS to set the image width to go with article header dynamically and max height to mobile view height, it will make the image keep changing image ratio and cropped the image as user zoom or use wider screen. Changed the CSS to keep the image ratio and increase the maximum height to larger mobile view. 