### PR TITLE
Double Build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Workplace 2030 microsite",
   "scripts": {
     "start": "npm run serve",
-    "build": "npx @11ty/eleventy",
+    "build": "npx @11ty/eleventy && npx @11ty/eleventy --output _site/workplace --pathprefix /workplace",
     "federalist": "npm run build",
     "dev": "concurrently npm:styles npm:serve",
     "serve": "npx @11ty/eleventy --serve --watch",
@@ -24,11 +24,8 @@
     "striptags": "^3.2.0"
   },
   "dependencies": {
-    "@uswds/uswds": "^3.4.1",
+    "@uswds/uswds": "^3.3.0",
     "elasticlunr": "^0.9.5",
     "fslightbox": "^3.3.2-2"
-  },
-  "overrides": {
-    "glob-parent@<5.1.2": "^5.1.2"
   }
 }


### PR DESCRIPTION
Adds an additional build step to build a mirror of the site in /workplace. This will allow the proxy from GSA to have a correctly configured site in the _site/workplace directory while still serving content for workplace.gsa.gov from _site.